### PR TITLE
fix: exclude unnecessary files from dist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,7 @@
 /composer.json              export-ignore
 /composer.lock              export-ignore
 /.cz.yaml                   export-ignore
+/docs                       export-ignore
 /examples                   export-ignore
 /.gitattributes             export-ignore
 /.github                    export-ignore
@@ -17,6 +18,7 @@
 /README.md                  export-ignore
 /SECURITY.md                export-ignore
 /tests                      export-ignore
+/.vscode                    export-ignore
 *.svg                       export-ignore
 *.png                       export-ignore
 


### PR DESCRIPTION
The VSCode config files were still there.